### PR TITLE
Add support for expo clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ logs
 
 .idea
 dist
+main

--- a/cli.py
+++ b/cli.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import requests
 import json
 

--- a/db/db.go
+++ b/db/db.go
@@ -433,7 +433,18 @@ func AddExpoClient(UUID string, expoID string) error {
 	err := SQLDB.QueryRow("SELECT UUID FROM expo WHERE UUID=?", UUID).Scan(&c.UUID)
 
 	if err == nil {
-		 return errors.New("Client already exists")
+		 update, err := SQLDB.Prepare("UPDATE expo SET expoID=? WHERE UUID=?")
+		 if err != nil {
+		 	return errors.New("Error create expo client update")
+		 }
+
+		 _, err = update.Exec(expoID, UUID)
+
+		 if err != nil {
+		 	return errors.New("Error updating client")
+		 }
+
+		 return nil
 	}
 
 	insert, err := SQLDB.Prepare("INSERT into expo(UUID, expoID) values(?, ?)")
@@ -452,5 +463,19 @@ func AddExpoClient(UUID string, expoID string) error {
 
 // RemoveExpoClient - removes the Expo Client associated with the device UUID
 func RemoveExpoClient(UUID string) error {
+	c := Expo{}
+	err := SQLDB.QueryRow("SELECT UUID FROM expo WHERE UUID=?", UUID).Scan(&c.UUID)
+
+	if err != nil {
+		return errors.New("Client not registered")
+	}
+
+	delete, err := SQLDB.Prepare("DELETE from expo WHERE UUID=(?)")
+	_, err = delete.Exec(UUID)
+
+	if err != nil {
+		return errors.New("Failed to delete Client from DB")
+	}
+
 	return nil
 }

--- a/db/db.go
+++ b/db/db.go
@@ -38,6 +38,11 @@ type Charge struct {
 	Query int64  `json:"query"`
 }
 
+type Expo struct {
+	UUID string `json:"UUID"`
+	ExpoID string `json:"expoID"`
+}
+
 //Init init sql
 func Init() {
 	var err error
@@ -76,25 +81,35 @@ func ResetDB() {
 //CreateTables create the user and posts tables
 func CreateTables() {
 	createTables := `
-	CREATE TABLE queries (
+	
+    CREATE TABLE queries (
 		key integer primary key autoincrement,
 		text varchar(255) not null,
 		type varchar(20) not null,
 		priority timestamp
 	);
-	CREATE TABLE resolved (
+	
+    CREATE TABLE resolved (
 		key integer primary key not null,
 		text varchar(255) not null,
 		type varchar(20) not null,
 		answer varchar(800) null,
 		list varchar(2400) null
 	);
-	CREATE TABLE charges (
+	
+    CREATE TABLE charges (
 		key varchar(255) primary key
 	);
+
+    CREATE TABLE expo (
+        UUID varchar(255) primary key not null,
+        expoID varchar(255) not null
+    );
+
 	DELETE from queries;
-  DELETE from resolved;
+    DELETE from resolved;
 	DELETE from charges;
+	DELETE from expo;
 	`
 	//Create the users table
 	_, err := SQLDB.Exec(createTables)
@@ -387,4 +402,55 @@ func GetQuestion(key int64) (Query, error) {
 		}
 	}
 	return q, nil
+}
+
+// GetExpoClients - gets all of the ExpoIDs to send push notifications to
+func GetExpoClients() ([]Expo, error) {
+
+	clients := []Expo{}
+
+	rows, err := SQLDB.Query("SELECT expoID from expo")
+	defer rows.Close() //close query connection when function returns
+	if err != nil {
+		return clients, err
+	}
+
+	for rows.Next() {
+		c := Expo{}
+		err = rows.Scan(&c.ExpoID)
+		if err != nil {
+			return clients, errors.New("Error parsing clients from DB")
+		}
+		clients = append(clients, c)
+	}
+
+	return clients, nil
+}
+
+// AddExpoClient - adds a new Expo Client to the list
+func AddExpoClient(UUID string, expoID string) error {
+	c := Expo{}
+	err := SQLDB.QueryRow("SELECT UUID FROM expo WHERE UUID=?", UUID).Scan(&c.UUID)
+
+	if err == nil {
+		 return errors.New("Client already exists")
+	}
+
+	insert, err := SQLDB.Prepare("INSERT into expo(UUID, expoID) values(?, ?)")
+
+	if err != nil {
+		return errors.New("Error creating expo client insert")
+	}
+
+	_, err = insert.Exec(UUID, expoID)
+	if err != nil {
+		return errors.New("Failed to insert client into db")
+	}
+
+	return nil
+}
+
+// RemoveExpoClient - removes the Expo Client associated with the device UUID
+func RemoveExpoClient(UUID string) error {
+	return nil
 }

--- a/handlers/expo.go
+++ b/handlers/expo.go
@@ -5,6 +5,7 @@ import (
     "jimmify-server/db"
     "jimmify-server/auth"
     "net/http"
+    "log"
 )
 
 type ExpoMsg struct {
@@ -32,6 +33,7 @@ func ExpoRegister(w http.ResponseWriter, r *http.Request) {
     err = db.AddExpoClient(msg.UUID, msg.ExpoID)
 
     if err != nil {
+        log.Println(err.Error())
         ReturnInternalServerError(w, err.Error())
         return
     }

--- a/handlers/expo.go
+++ b/handlers/expo.go
@@ -1,0 +1,70 @@
+package handlers
+
+import (
+    "encoding/json"
+    "jimmify-server/db"
+    "jimmify-server/auth"
+    "net/http"
+)
+
+type ExpoMsg struct {
+    UUID string    `json:"UUID"`
+    Token string   `json:"token"`
+    ExpoID string  `json:"expoID"`
+}
+
+func ExpoRegister(w http.ResponseWriter, r *http.Request) {
+    var msg ExpoMsg
+    response := make(map[string]interface{})
+
+    err := json.NewDecoder(r.Body).Decode(&msg)
+    if err != nil {
+        ReturnStatusBadRequest(w, "Failed to decode json")
+        return
+    }
+
+    _, err = auth.CheckToken(msg.Token)
+    if err != nil {
+        ReturnUnauthorized(w, err.Error())
+        return
+    }
+
+    err = db.AddExpoClient(msg.UUID, msg.ExpoID)
+
+    if err != nil {
+        ReturnInternalServerError(w, err.Error())
+        return
+    }
+
+    w.WriteHeader(http.StatusOK)
+    response["status"] = true
+    json.NewEncoder(w).Encode(response)
+}
+
+func ExpoUnRegister(w http.ResponseWriter, r *http.Request) {
+    var msg ExpoMsg
+    response := make(map[string]interface{})
+
+    err := json.NewDecoder(r.Body).Decode(&msg)
+    if err != nil {
+        ReturnStatusBadRequest(w, "Failed to decode json")
+        return
+    }
+
+    _, err = auth.CheckToken(msg.Token)
+    if err != nil {
+        ReturnUnauthorized(w, err.Error())
+        return
+    }
+
+    err = db.RemoveExpoClient(msg.UUID)
+
+    if err != nil {
+        ReturnInternalServerError(w, err.Error())
+        return
+    }
+
+    w.WriteHeader(http.StatusOK)
+    response["status"] = true
+    json.NewEncoder(w).Encode(response)
+}

--- a/handlers/query.go
+++ b/handlers/query.go
@@ -3,7 +3,7 @@ package handlers
 import (
 	"encoding/json"
 	"jimmify-server/db"
-	"jimmify-server/firebase"
+	"jimmify-server/notifications"
 	"net/http"
 )
 
@@ -38,7 +38,7 @@ func Query(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if PushEnabled == true {
-		firebase.Push("Jimmy Query", q.Text)
+		notifications.Push("Jimmy Query", q.Text)
 	}
 
 	w.WriteHeader(http.StatusOK)

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"flag"
 	"jimmify-server/auth"
 	"jimmify-server/db"
-	"jimmify-server/firebase"
+	"jimmify-server/notifications"
 	"jimmify-server/handlers"
 	"log"
 	"net/http"
@@ -26,7 +26,7 @@ func main() {
 	}
 	r := getRoutes(path) //create routes
 
-	firebase.Init()
+	notifications.Init()
 
 	log.Println("Starting Jimmy Server")
 	http.ListenAndServe(":3000", r)
@@ -47,6 +47,8 @@ func getRoutes(path string) *http.ServeMux {
 	mux.HandleFunc("/api/charge", handlers.Charge)
 	mux.HandleFunc("/api/login", handlers.Login)
 	mux.HandleFunc("/api/renew", handlers.Renew)
+	mux.HandleFunc("/api/expo/add", handlers.ExpoRegister)
+	mux.HandleFunc("/api/expo/del", handlers.ExpoUnRegister)
 	return mux
 }
 

--- a/notifications/expo.go
+++ b/notifications/expo.go
@@ -1,0 +1,20 @@
+package notifications
+
+import (
+	"jimmify-server/db"
+	"github.com/adierkens/expo-server-sdk-go"
+	"log"
+)
+
+var client = expo.NewExpo()
+
+func PushExpo(title string, body string) {
+	q, err := db.GetExpoClients()
+
+	log.Println(q)
+
+	if err != nil {
+		log.Println("Unable to fetch expo client list");
+	}
+
+}

--- a/notifications/expo.go
+++ b/notifications/expo.go
@@ -9,12 +9,29 @@ import (
 var client = expo.NewExpo()
 
 func PushExpo(title string, body string) {
-	q, err := db.GetExpoClients()
-
-	log.Println(q)
+	clients, err := db.GetExpoClients()
+	messages := []*expo.ExpoPushMessage{}
 
 	if err != nil {
 		log.Println("Unable to fetch expo client list");
 	}
 
+	payload := make(map[string]interface{})
+	payload["title"] = title
+	payload["body"] = body
+
+	for _, c := range clients {
+		msg := expo.NewExpoPushMessage()
+		msg.To = c.ExpoID
+		msg.Title = title
+		msg.Body = body
+		msg.Data = payload
+
+		messages = append(messages, msg)
+	}
+
+	_, err = client.SendPushNotifications(messages)
+	if err != nil {
+		log.Println(err.Error())
+	}
 }

--- a/notifications/firebase.go
+++ b/notifications/firebase.go
@@ -1,4 +1,4 @@
-package firebase
+package notifications
 
 import (
 	"bytes"
@@ -26,7 +26,7 @@ func Init() {
 }
 
 //Push : Sends a push notification using Google Cloud Messaging
-func Push(title string, body string) {
+func PushFirebase(title string, body string) {
 	var jsonStr = []byte(fmt.Sprintf(`{"to": "/topics/%s", "priority" : "high", "notification": {"body": "%s", "icon" : "ic_notify", "tag":"JIMMY", "title": "%s"}}`, topic, body, title))
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonStr))
 	req.Header.Set("Authorization", "key="+serverKey)

--- a/notifications/notifications.go
+++ b/notifications/notifications.go
@@ -1,0 +1,6 @@
+package notifications
+
+func Push(title string, body string) {
+	PushFirebase(title, body)
+	PushExpo(title, body)
+}

--- a/stripe-wrapper/stripe-wrapper.go
+++ b/stripe-wrapper/stripe-wrapper.go
@@ -4,7 +4,7 @@ import (
 	"github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/charge"
 	"jimmify-server/db"
-	"jimmify-server/firebase"
+	"jimmify-server/notifications"
 	"log"
 	"os"
 )
@@ -33,6 +33,6 @@ func PrioritizeQuestion(token string, qkey int64) error {
 	if err != nil {
 		return err
 	}
-	firebase.Push("Jimmy Payment", "Dolla Dolla Bill Ya'll")
+	notifications.Push("Jimmy Payment", "Dolla Dolla Bill Ya'll")
 	return err
 }


### PR DESCRIPTION
- Adds 2 new API endpoints (both require authentication):
   - `/api/expo/add` -- Adds a new UUID -> expoID mapping
   - `/api/expo/del` -- Removes a UUID from the client list

- Adds a new DB table called `expo` with a `UUID` and `expoID` column

**TODO:**
- [x] Hook up `del` api to db
- [x] Trigger `expo` push notifications when we get a new question/answer

